### PR TITLE
Request: Ldap optional

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,5 +21,16 @@
       "error_unable_map_queue": "There was a problem mapping the printer queue - please try again. If the problem persists, contact your support team for further assistance.",
       "error_preselected_queue": "The printer queue '%s' is already configured on your Mac."
     }
+  },
+  "ldap": {
+     "group": {
+         "name_format": "PrinterGroup-*"
+     },
+     "messages": {
+         "error": "Unable to contact LDAP server. Please contact your support team for further assistance.",
+         "prompt_creds": "Please enter your Active Directory password."
+     },
+     "search_base": "dc=ad,dc=domain,dc=com",
+     "server": "ldap://ad.domain.com"
   }
 }

--- a/config.json
+++ b/config.json
@@ -27,8 +27,7 @@
          "name_format": "PrinterGroup-*"
      },
      "messages": {
-         "error": "Unable to contact LDAP server. Please contact your support team for further assistance.",
-         "prompt_creds": "Please enter your Active Directory password."
+         "error": "Unable to contact LDAP server. Please contact your support team for further assistance."
      },
      "search_base": "dc=ad,dc=domain,dc=com",
      "server": "ldap://ad.domain.com"

--- a/examples/printers.csv
+++ b/examples/printers.csv
@@ -1,4 +1,4 @@
-DisplayName,URI,Driver,DriverTrigger,Location,Options
-FirstPrinter,smb://print.server.tld/FirstPrinter,,,Brown Hall,"APOptionalDuplexer=True printer-is-shared=false auth-info-required=negotiate"
+DisplayName,URI,Driver,DriverTrigger,Location,Options,ADFilterGroup
+FirstPrinter,smb://print.server.tld/FirstPrinter,,,Brown Hall,"APOptionalDuplexer=True printer-is-shared=false auth-info-required=negotiate",PrinterGroup-FirstPrinter
 MFD,smb://print.server.tld/MFD,/Library/Printers/PPDs/Contents/Resources/RICOH Aficio MP C3002.gz,InstallRicohDrivers,Brown Hall,"ColorModel=Gray Finisher=FinKINGB ImageableArea=Letter PageRegion=Letter PageSize=Letter PaperDimension=Letter printer-is-shared=false auth-info-required=negotiate"
-Another,smb://print.server.tld/Another,,,Blue Hall,"APOptionalDuplexer=True printer-is-shared=false auth-info-required=negotiate"
+Another,smb://print.server.tld/Another,,,Blue Hall,"APOptionalDuplexer=True printer-is-shared=false auth-info-required=negotiate",PrinterGroup-Another

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -234,6 +234,7 @@ def search_for_driver(driver, trigger):
 
 
 def add_queue(queue):
+    """Add the printer queue to the computer"""
     # Reference the queue dictionary by name
     q = QUEUE_DEFINITIONS[queue]
 

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -27,12 +27,12 @@ CDPATH = "{config[cocoaDialog][path]}" # pylint: disable=line-too-long
 # Queue Definitions
 ###############################################################################
 
-json_definitions = \
+JSON_DEFINITIONS = \
 """
 {queues}
 """
 
-queue_definitions = json.loads(json_definitions)
+QUEUE_DEFINITIONS = json.loads(JSON_DEFINITIONS)
 
 ###############################################################################
 # Program Logic - Here be dragons!
@@ -42,7 +42,7 @@ queue_definitions = json.loads(json_definitions)
 class Logger(object):
     """Super simple logging class"""
     @classmethod
-    def log(self, message, log_level=syslog.LOG_ALERT):
+    def log(cls, message, log_level=syslog.LOG_ALERT):
         """Log to the syslog and stdout"""
         syslog.syslog(log_level, "PRINTMAPPER: " + message)
         print message
@@ -161,7 +161,7 @@ def get_currently_mapped_queues():
 def build_printer_queue_list(current_queues, filter_key, filter_value):
     """Builds a list of available print queues for GUI presentation"""
     display_list = []
-    for queue, values in queue_definitions.items():
+    for queue, values in QUEUE_DEFINITIONS.items():
 
         valid_queue = False
         if not values['DisplayName'] in current_queues:
@@ -241,7 +241,7 @@ def search_for_driver(driver, trigger):
 
 def add_queue(queue):
     # Reference the queue dictionary by name
-    q = queue_definitions[queue]
+    q = QUEUE_DEFINITIONS[queue]
 
     # Determine whether we need to handle custom drivers
     # By convention, a driver path only appears in the queue dict if a custom
@@ -286,7 +286,7 @@ def add_queue(queue):
     except subprocess.CalledProcessError as e:
         Logger.log('There was a problem mapping the queue!')
         Logger.log('Attempted command: ' + ' '.join(cmd))
-        show_message("{config[gui][messages][error_unable_map_queue]}")# pylint: disable=line-too-long
+        show_message("{config[gui][messages][error_unable_map_queue]}") # pylint: disable=line-too-long
         quit()
 
 
@@ -313,7 +313,7 @@ def main():
             selected_queue = args.preselected_queue
         else:
             show_message(("{config[gui][messages][error_preselected_queue]}")
-                          % args.preselected_queue)
+                         % args.preselected_queue)
             error_and_exit()
     else:
         # Make sure cocoaDialog is installed

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -18,7 +18,7 @@ __version__ = "0.1.5"
 BRANDICON = "{config[gui][brand_icon]}" # pylint: disable=line-too-long
 PRINTERICON = "{config[gui][printer_icon]}" # pylint: disable=line-too-long
 
-# Path to JAMF binary
+# Path to Jamf binary
 JAMF = "/usr/local/bin/jamf"
 CDPATH = "{config[cocoaDialog][path]}" # pylint: disable=line-too-long
 
@@ -61,11 +61,11 @@ def parse_args():
                      "key as argument 5, and a filter value as arugment 6.")
     )
     parser.add_argument("jamf_mount", type=str, nargs='?',
-                        help="JAMF-passed target drive mount point")
+                        help="Jamf-passed target drive mount point")
     parser.add_argument("jamf_hostname", type=str, nargs='?',
-                        help="JAMF-passed computer hostname")
+                        help="Jamf-passed computer hostname")
     parser.add_argument("jamf_user", type=str, nargs='?',
-                        help="JAMF-passed name of user running policy")
+                        help="Jamf-passed name of user running policy")
     parser.add_argument("preselected_queue", type=str, nargs='?',
                         help="DisplayName of an available queue to map "
                              "without prompting user for selection")
@@ -124,12 +124,13 @@ def run_jamf_policy(trigger, quiet=False):
         progress_bar.terminate()
 
     if "No policies were found for the" in policy_return:
-        Logger.log("Unable to run JAMF policy via trigger " + trigger)
+        Logger.log("Unable to run Jamf policy via trigger " + trigger)
         return False
     elif "Submitting log to" in policy_return:
-        Logger.log("Successfully ran JAMF policy via trigger " + trigger)
+        Logger.log("Successfully ran Jamf policy via trigger " + trigger)
         return True
 
+    return False
 
 def check_for_cocoadialog():
     """
@@ -212,7 +213,7 @@ def prompt_queue(list_of_queues):
 
 
 def install_drivers(trigger):
-    """Installs required drivers via JAMF policy given a trigger value"""
+    """Installs required drivers via Jamf policy given a trigger value"""
     Logger.log("Attempting to install drivers via policy trigger " + trigger)
 
     if not run_jamf_policy(trigger):
@@ -223,7 +224,7 @@ def install_drivers(trigger):
 
 def search_for_driver(driver, trigger):
     """Searches the system for the appropriate driver and if not found,
-       attempts to install it via JAMF policy"""
+       attempts to install it via Jamf policy"""
     if not os.path.exists(driver):
         Logger.log("The driver was not found at " + driver)
         if not install_drivers(trigger):
@@ -285,10 +286,10 @@ def add_queue(queue):
 
 def main():
     """Manage arguments and run workflow"""
-    # Parse command line / JAMF-passed arguments
+    # Parse command line / Jamf-passed arguments
     parser = parse_args()
     # parse_known_args() works around potentially empty arguments passed by
-    # a JAMF policy
+    # a Jamf policy
     args = parser.parse_known_args()[0]
 
     # Build list of currently mapped queues on client

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -162,23 +162,23 @@ def get_currently_mapped_queues():
 def build_printer_queue_list(current_queues, filter_key, filter_value):
     """Builds a list of available print queues for GUI presentation"""
     display_list = []
-    for queue, values in QUEUE_DEFINITIONS.items():
+    for queue in QUEUE_DEFINITIONS.values():
 
         # Skip if the printer is already installed
-        if values.get('DisplayName') in current_queues:
+        if queue.get('DisplayName') in current_queues:
             continue
 
         # Skip if the CUPSName field is present and is already installed
-        if values.get('CUPSName') in current_queues:
+        if queue.get('CUPSName') in current_queues:
             continue
 
         # Skip if a filter is enabled and it doesn't match
-        if filter_key and values.get(filter_key):
-            if filter_value not in values.get(filter_key):
+        if filter_key and queue.get(filter_key):
+            if filter_value not in queue.get(filter_key):
                 continue
 
         # Add the printer to the list of available printers
-        display_list.append(values.get('DisplayName'))
+        display_list.append(queue.get('DisplayName'))
 
 
     if len(display_list) >= 1:

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -234,6 +234,7 @@ def user_ldap_groups(username):
     for attribute in dn:
         if attribute.startswith('dn: '):
             user_dn = attribute.split(':')[1].strip()
+            break
 
     search_filter = '(member:1.2.840.113556.1.4.1941:='+user_dn+')'
     if "{config[ldap][group][name_format]}" != "":

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -49,7 +49,7 @@ class Logger(object):
 
 
 # Initialize Logger
-Logger = Logger()
+Logger()
 
 
 def parse_args():
@@ -92,6 +92,7 @@ def show_message(message_text, heading="{config[gui][window_title]}"):
     return True
 
 
+# pylint: disable=C0103
 def error_and_exit(no_cocoaDialog=False):
     """
     Display a generic error message (if cocoaDialog is installed) then quit
@@ -137,8 +138,8 @@ def check_for_cocoadialog():
     """
     if not os.path.exists(CDPATH):
         return run_jamf_policy("{config[cocoaDialog][install_trigger]}", True)
-    else:
-        return True
+
+    return True
 
 
 def get_currently_mapped_queues():
@@ -146,7 +147,7 @@ def get_currently_mapped_queues():
     try:
         Logger.log('Gathering list of currently mappped queues')
         lpstat_result = subprocess.check_output(['/usr/bin/lpstat', '-p'])
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         Logger.log('No current print queues found')
         lpstat_result = None
 
@@ -209,13 +210,13 @@ def prompt_queue(list_of_queues):
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
     prompt_return, error = queue_dialog.communicate()
-    if not prompt_return == "Cancel\n":
+    if prompt_return != "Cancel\n":
         selected_queue = prompt_return.splitlines()[1]
         Logger.log('User selected queue ' + selected_queue)
         return selected_queue
-    else:
-        Logger.log('User canceled queue selection')
-        return False
+
+    Logger.log('User canceled queue selection')
+    return False
 
 
 def install_drivers(trigger):
@@ -224,8 +225,8 @@ def install_drivers(trigger):
 
     if not run_jamf_policy(trigger):
         return False
-    else:
-        return True
+
+    return True
 
 
 def search_for_driver(driver, trigger):
@@ -283,7 +284,7 @@ def add_queue(queue):
         show_message(("{config[gui][messages][success_queue_added]}" # pylint: disable=line-too-long
                       % q['DisplayName']), "Success!")
         quit()
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         Logger.log('There was a problem mapping the queue!')
         Logger.log('Attempted command: ' + ' '.join(cmd))
         show_message("{config[gui][messages][error_unable_map_queue]}") # pylint: disable=line-too-long

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -209,8 +209,8 @@ def user_ldap_groups(username):
     user_groups = []
 
     if not has_kerberos_ticket():
-        show_message("{config[ldap][messages][error]}") # pylint: disable=line-too-long
-        quit()
+        Logger.log("Kerberos ticket not found. No AD groups returned.")
+        return user_groups
 
     try:
         dn = subprocess.check_output(['ldapsearch', '-LLL',
@@ -223,7 +223,6 @@ def user_ldap_groups(username):
     except subprocess.CalledProcessError as e:
         if e.returncode == 254:
             Logger.log('Encountered an authentication error while searching ldap.')
-            Logger.log('Prompting for credentials and trying again.')
         else:
             Logger.log('Unknown error searching ldap. (Error code: '+str(e.returncode)+')')
 

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -180,13 +180,12 @@ def build_printer_queue_list(current_queues, filter_key, filter_value):
         # Add the printer to the list of available printers
         display_list.append(queue.get('DisplayName'))
 
-
-    if len(display_list) >= 1:
-        return sorted(display_list)
-    else:
+    if not display_list:
         Logger.log("No currently-unmapped queues are available")
         show_message("{config[gui][messages][error_no_queues_available]}") # pylint: disable=line-too-long
         quit()
+
+    return sorted(display_list)
 
 
 def prompt_queue(list_of_queues):

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -209,7 +209,7 @@ def user_ldap_groups(username):
     user_groups = []
 
     if not has_kerberos_ticket():
-        Logger.log("Kerberos ticket not found. No AD groups returned.")
+        Logger.log("Kerberos ticket not found. AD group filtering disabled.")
         return user_groups
 
     try:

--- a/source/printer-installer.source.py
+++ b/source/printer-installer.source.py
@@ -164,29 +164,22 @@ def build_printer_queue_list(current_queues, filter_key, filter_value):
     display_list = []
     for queue, values in QUEUE_DEFINITIONS.items():
 
-        valid_queue = False
-        if not values['DisplayName'] in current_queues:
-            # If the CUPSName field is present check for its value among
-            # mapped queues
-            if 'CUPSName' in values:
-                if values['CUPSName'] not in current_queues:
-                    valid_queue = True
-            else:
-                valid_queue = True
+        # Skip if the printer is already installed
+        if values.get('DisplayName') in current_queues:
+            continue
 
+        # Skip if the CUPSName field is present and is already installed
+        if values.get('CUPSName') in current_queues:
+            continue
 
-        if valid_queue:
-            # Queue is available but not currently mapped
-            if filter_key and values.get(filter_key):
-                # Filter is applied, and the passed key exists in the queue
-                # definitions, so check for match condition
-                if filter_value in values[filter_key]:
-                    # Match condition met, so add queue to list
-                    display_list.append(values['DisplayName'])
-                # Implicit else of condition not met, do not add queue to list
-            elif not filter_key:
-                # No filter applied, so just add the queue to the list
-                display_list.append(values['DisplayName'])
+        # Skip if a filter is enabled and it doesn't match
+        if filter_key and values.get(filter_key):
+            if filter_value not in values.get(filter_key):
+                continue
+
+        # Add the printer to the list of available printers
+        display_list.append(values.get('DisplayName'))
+
 
     if len(display_list) >= 1:
         return sorted(display_list)


### PR DESCRIPTION
The Ldap integration in MScottBlakes code is cool,  but for Jamf users like myself it may be desireable to use the ldap filtering feature of the Jamf server, rather than at the command line level...
Or, for example,  ldap contact may not be available in some cases.

Example: if a machine is offsite, it can access the policy via jamf self-service (which is publicly available in our ennvironent) but can't contact ldap server... Our server always has ldap access though, so could do that part.

Anyway, I'm using version .15 right now, but if this functionality is  eventually folded into Haircut's  main code base, the option to turn off the ldap/adfilter would be good.

(That being said, props to both haircut for his original work and scotts mods)